### PR TITLE
Allow specifying R path explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Set up (the latest version of) [RStudio Server](https://www.rstudio.com/products
 * `rstudio_server_www_port` [default: `8787`]: The port you want RStudio to listen on
 * `rstudio_server_www_address` [default: `0.0.0.0`]: The address you want RStudio to listen on
 * `rstudio_server_auth_required_user_group` [optional]: Limits the users who can login to RStudio to the members of a this group (e.g. `rstudio_users`)
+* `rsession-which-r` [optional]: Override which version of R is used.
 
 ## Dependencies
 

--- a/templates/etc/rstudio/rserver.conf.j2
+++ b/templates/etc/rstudio/rserver.conf.j2
@@ -7,3 +7,6 @@ www-address={{ rstudio_server_www_address }}
 {% if rstudio_server_auth_required_user_group is defined %}
 auth-required-user-group={{ rstudio_server_auth_required_user_group }}
 {% endif %}
+{% if rstudio_server_which_r is defined %}
+rsession-which-r={{ rstudio_server_which_r }}
+{% endif %}


### PR DESCRIPTION
This will help people who install R from conda, for example.